### PR TITLE
Add file filter for strings.xml and plurals.xml

### DIFF
--- a/src/com/brouken/wear/modder/Main.java
+++ b/src/com/brouken/wear/modder/Main.java
@@ -25,7 +25,7 @@ public class Main {
     }
 
     private static void processFile(Path path) {
-        if (!path.toString().toLowerCase().endsWith(".xml"))
+        if (!path.toString().toLowerCase().endsWith(".xml") || path.toString().toLowerCase().endsWith("strings.xml") || path.toString().toLowerCase().endsWith("plurals.xml"))
             return;
 
         System.out.println(path.toString());


### PR DESCRIPTION
The program sometimes (testet with https://play.google.com/store/apps/details?id=org.openhab.habdroid) does weird replacements in strings and plurals files (compiler failes because of that). Since these files contain no dimensions (e. g. size of ui elements), they can simply be filtered out.